### PR TITLE
add q-numbers for P17 and P700

### DIFF
--- a/pb2wb/common/settings.py
+++ b/pb2wb/common/settings.py
@@ -92,8 +92,8 @@ BASE_IMPORT_OBJECTS = {
     'FACTGRID':
       {'BIB':{
         'BETA': {'Language': 'es', 'label': 'BETA', 'qnum': 'Q254471', 'p17': 'Q425065', 'p700': 'Q447226'},
-        'BITECA': {'Language': 'ca', 'label': 'BITECA', 'qnum': 'Q256810', 'p17': '', 'p700': ''},
-        'BITAGAP': {'Language': 'pt', 'label': 'BITAGAP', 'qnum': 'Q256809', 'p17': '', 'p700': ''}
+        'BITECA': {'Language': 'ca', 'label': 'BITECA', 'qnum': 'Q256810', 'p17': 'Q425065', 'p700': 'Q447226'},
+        'BITAGAP': {'Language': 'pt', 'label': 'BITAGAP', 'qnum': 'Q256809', 'p17': 'Q425065', 'p700': 'Q447226'}
       },
       'SSH_USER': 'pi',
       'SERVER': 'philobiblon.cog.berkeley.edu',


### PR DESCRIPTION
The P17 and P700 qnumbers for biteca and bitagap on FG should be same as for beta.
```
P700 = 'Q447226'
https://database.factgrid.de/wiki/Property:P700
Statement refers to (P700)
https://database.factgrid.de/wiki/Item:Q447226
PhiloBiblon object (Q447226)

P17 = 'Q425065'
https://database.factgrid.de/wiki/Property:P17
Dataset complaint (P17)
https://database.factgrid.de/wiki/Item:Q425065
PhiloBiblon automation pending (Q425065)
```