### PR TITLE
include RELATED_BIOID in list of id fields

### DIFF
--- a/pb2wb/common/data_dictionary.py
+++ b/pb2wb/common/data_dictionary.py
@@ -142,6 +142,7 @@ DATADICT = {
             'TITLE_GEOID',
             'MILESTONE_GEOID',
             'AFFILIATION_GEOID',
+            'RELATED_BIOID',
             'RELATED_BIOID_SUBJECT',
             'RELATED_BIOID_OBJECT',
             'RELATED_INSID',


### PR DESCRIPTION
include RELATED_BIOID in list of id fields for bio so it gets propagated to husband, wife, etc.